### PR TITLE
Changed the sidebar to stretch to visible height

### DIFF
--- a/public/app.css
+++ b/public/app.css
@@ -46,3 +46,13 @@ main {
   font-size: 1.5em;
   padding: 0.2em;
 }
+@media (min-width: 768px) {
+  .mojo-footer {
+    height: 4.5rem;
+  }
+
+  .mojo-sidebar {
+    /* visible - footer - (mojobar-brand + padding + padding) */
+    min-height: calc(100vh - 4.5rem - (38px + 0.3125rem * 2 + 0.5rem * 2));
+  }
+}


### PR DESCRIPTION
This change allows the sidebar to stretch down to the footer even if the main content is not tall enough.

![Screenshot 2022-06-20 at 09-51-53 FAQ](https://user-images.githubusercontent.com/45729/174608175-e8c7ccdc-ed7d-4cdb-9889-9eb7d78d349c.png)
